### PR TITLE
python 3 compatible, fix typo in readme

### DIFF
--- a/GitResultsManager/GitResultsManager.py
+++ b/GitResultsManager/GitResultsManager.py
@@ -16,6 +16,8 @@
 #  GitResultsManager by by Jason Yosinski <jason@yosinski.com>
 #  Included asyncproc code by Thomas Bellman <bellman@lysator.liu.se>
 
+from __future__ import print_function
+
 import os
 import sys
 import logging
@@ -59,7 +61,7 @@ def makeAsync(fd):
 def readAsync(fd):
     try:
         return fd.read()
-    except IOError, err:
+    except IOError as err:
         if err.errno != errno.EAGAIN:
             raise err
         else:
@@ -176,11 +178,11 @@ def runCmd(args, supressErr=False):
     code = proc.wait()
 
     if code != 0 and not supressErr:
-        print out
-        print err
+        print(out)
+        print(err)
         raise Exception('Got error from running command with args ' + repr(args))
 
-    return code, out, err
+    return code, out.decode('utf-8'), err.decode('utf-8')
 
 
 
@@ -260,7 +262,7 @@ class GitResultsManager(object):
                 raise Exception('Tried to resume run from "%s", but it is not a results directory', self._resumeExistingRun)
 
             with open(os.path.join(self._resumeExistingRun, 'diary'), 'r') as diaryFile:
-                firstLine = diaryFile.next()
+                firstLine = next(diaryFile)
             ints = [int(xx) for xx in firstLine.split()[0].split('.')]
             year,month,day,hour,minute,second,ms = ints
 
@@ -269,7 +271,7 @@ class GitResultsManager(object):
             self.startProc = None
             self.diary = False   # External run, so it's not a diary we're managing
 
-            print 'grabbed time:', self.startWall
+            print('grabbed time:', self.startWall)
 
         else:
             self._resultsSubdir = resultsSubdir
@@ -341,22 +343,22 @@ class GitResultsManager(object):
         # print the command that was executed
         gitDisableWarning = 'WARNING: GitResultsManager running in GIT_DISABLED mode: no git information saved! (Is %s in a git repo?)' % os.getcwd()
         if not useGit:
-            print >>sys.stderr, gitDisableWarning
-        print '  Logging directory:', self.rundir
-        print ' Raw entire command:', ' '.join(sys.argv)
-        print '           Hostname:', hostname()
-        print '  Working directory:', os.getcwd()
+            print(gitDisableWarning, file=sys.stderr)
+        print('  Logging directory:', self.rundir)
+        print(' Raw entire command:', ' '.join(sys.argv))
+        print('           Hostname:', hostname())
+        print('  Working directory:', os.getcwd())
         if not self.diary:
-            print '<diary not saved>'
+            print('<diary not saved>')
             # just log these three lines
             with open(os.path.join(self.rundir, 'diary'), 'w') as ff:
                 if not useGit:
-                    print >>ff, gitDisableWarning
-                print >>ff, '  Logging directory:', self.rundir
-                print >>ff, ' Raw entire command:', ' '.join(sys.argv)
-                print >>ff, '           Hostname:', hostname()
-                print >>ff, '  Working directory:', os.getcwd()
-                print >>ff, '<diary not saved>'
+                    print(gitDisableWarning, file=ff)
+                print('  Logging directory:', self.rundir, file=ff)
+                print(' Raw entire command:', ' '.join(sys.argv), file=ff)
+                print('           Hostname:', hostname(), file=ff)
+                print('  Working directory:', os.getcwd(), file=ff)
+                print('<diary not saved>', file=ff)
 
         if useGit:
             with open(os.path.join(self.rundir, 'gitinfo'), 'w') as ff:
@@ -381,13 +383,13 @@ class GitResultsManager(object):
         if not self.diary:
             # just log these couple lines before resetting our name
             with open(os.path.join(self.rundir, 'diary'), 'a') as ff:
-                print >>ff, '       Wall time: ', fmtSeconds(time.time() - self.startWall)
+                print('       Wall time: ', fmtSeconds(time.time() - self.startWall), file=ff)
                 if procTime:
-                    print >>ff, '  Processor time: ', procTimeSec
+                    print('  Processor time: ', procTimeSec, file=ff)
         self._name = None
-        print '       Wall time: ', fmtSeconds(time.time() - self.startWall)
+        print('       Wall time: ', fmtSeconds(time.time() - self.startWall))
         if procTime:
-            print '  Processor time: ', procTimeSec
+            print('  Processor time: ', procTimeSec)
         if self.diary:
             self._outLogger.finishCapture()
             self._outLogger = None
@@ -611,7 +613,7 @@ class AsyncProcess(object):
             if self._exitstatus is None:
                 _killer(self.pid(), _sigkill)
         else:
-            print >>sys.stderr, 'Process object was never created. Maybe the program does not exist?'
+            print('Process object was never created. Maybe the program does not exist?', file=sys.stderr)
 
     def pid(self):
         """Return the process id of the process.
@@ -880,12 +882,12 @@ class ProcessManager(object):
 
 
 if __name__ == '__main__':
-    print 'This is just a simple demo. See the examples directory in the GitResultsManager distribution for more detailed examples.'
+    print('This is just a simple demo. See the examples directory in the GitResultsManager distribution for more detailed examples.')
 
     resman.start()
-    print 'this is being logged to the %s directory' % resman.rundir
+    print('this is being logged to the %s directory' % resman.rundir)
     time.sleep(1)
-    print 'this is being logged to the %s directory' % resman.rundir
+    print('this is being logged to the %s directory' % resman.rundir)
     time.sleep(1)
-    print 'this is being logged to the %s directory' % resman.rundir
+    print('this is being logged to the %s directory' % resman.rundir)
     resman.stop()

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Notice that it complains it cannot find the GIT_RESULTS_MANAGER_DIR
 environment variable. This is how the program knows it is not being
 run from within `resman`. Now, try using `resman` to run it:
 
-    resman run-name ./demo-c
+    resman -r run-name ./demo-c
 
 Output:
 

--- a/bin/resman
+++ b/bin/resman
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
+
 import os
 import sys
 import select
@@ -30,12 +32,12 @@ def main():
                     diary=not args.nodiary,
                     createResultsDirIfMissing=not args.nomkdir)
 
-    print ' Raw script command:', ' '.join(args.command)
+    print(' Raw script command:', ' '.join(args.command))
     args.command = [item.replace('GIT_RESULTS_MANAGER_DIR', gitresman.rundir) for item in args.command]
-    print '     Script command:', ' '.join(args.command)
+    print('     Script command:', ' '.join(args.command))
         
     os.environ['GIT_RESULTS_MANAGER_DIR'] = gitresman.rundir
-    print
+    print()
     proc = subprocess.Popen(args.command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     makeAsync(proc.stdout)
@@ -54,16 +56,16 @@ def main():
         stderrBlob = readAsync(proc.stderr)
 
         if stdoutBlob:
-            print stdoutBlob,
+            print(stdoutBlob, end=' ')
         if stderrBlob:
-            print >>sys.stderr, stderrBlob,
+            print(stderrBlob, end=' ', file=sys.stderr)
 
         exitCode = proc.poll()
         if exitCode != None:
             break
 
-    print
-    print '       Exit code: ', exitCode
+    print()
+    print('       Exit code: ', exitCode)
     
     gitresman.stop(procTime = False)
 


### PR DESCRIPTION
Makes GitResultsManager python 3 compatible. It is still backward compatible with python 2. Changes include:
* print statements
* exceptions
* decoding bytes to strings
* next iterators